### PR TITLE
Add strict mode to strictly match hex tokens

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@
 
 'use strict';
 
-module.exports = function hexColorRegex() {
-  var regex = /#([a-f0-9]{6}|[a-f0-9]{3})\b/gi
+module.exports = function hexColorRegex(config) {
+  config = config || {};
+  var regex = config.strict ? /^#([a-f0-9]{6}|[a-f0-9]{3})\b$/gi : /#([a-f0-9]{6}|[a-f0-9]{3})\b/gi
   return regex;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hex-color-regex",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Regular expression (regex) for matching hex color values from string.",
   "scripts": {
     "lint": "jshint index.js && jscs index.js --reporter inline",

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,13 @@ npm i --save hex-color-regex
 npm test
 ```
 
+## Parameters
+
+### strict 
+
+_default: false_
+
+Tests also to see if the hex is the _only_ token passed in (adds ^ to the beginning and $ to the end.)
 
 ## Usage
 > For more use-cases see the [tests](./test.js)
@@ -28,6 +35,7 @@ hexColorRegex().test('708135') //=> false
 hexColorRegex().test('ffffff') //=> false
 hexColorRegex().test('afebef') //=> false
 hexColorRegex().test('#113141}') //=> false, for now
+hexColorRegex({strict:true}).test('http://www.example.com/index.html#f06d06}') //=> false
 
 hexColorRegex().test('#afebe3') //=> true
 hexColorRegex().test('#AFEBE3') //=> true

--- a/test.js
+++ b/test.js
@@ -84,6 +84,8 @@ var threeDigits = {
   ]
 };
 
+var urlTest = 'http://www.example.com/index.html#f06d06';
+
 sixDigits.pass.forEach(function(hex) {
   mukla('should be `true` when `'+ hex +'` value').strictEqual(regex().test(hex), true);
 });
@@ -97,3 +99,7 @@ threeDigits.pass.forEach(function(hex) {
 threeDigits.fail.forEach(function(hex) {
   mukla('should be `false` when `'+ hex +'` hex value').strictEqual(regex().test(hex), false);
 });
+mukla('should be `false` when `' + urlTest + '` is passed in with strict mode').strictEqual(regex({strict:true}).test(urlTest), false);
+mukla('should be `true` when `' + urlTest + '` is passed in without strict mode').strictEqual(regex().test(urlTest), true);
+
+


### PR DESCRIPTION
Went ahead and did it.
- Added strict mode
- Updated README.md to reflect the addition
- Bumped version to 1.1.0 (happy to take that out; just seemed like the right thing to do)
- Added tests to cover the new functionality
