### PR TITLE
alpha channel support

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,5 +10,5 @@
 module.exports = function hexColorRegex (opts) {
   opts = opts && typeof opts === 'object' ? opts : {}
 
-  return opts.strict ? /^#([a-f0-9]{6}|[a-f0-9]{3})\b$/i : /#([a-f0-9]{6}|[a-f0-9]{3})\b/gi
+  return opts.strict ? /^#([a-f0-9]{3,4}|[a-f0-9]{4}(?:[a-f0-9]{2}){1,2})\b$/i : /#([a-f0-9]{3}|[a-f0-9]{4}(?:[a-f0-9]{2}){0,2})\b/gi
 }

--- a/test.js
+++ b/test.js
@@ -87,6 +87,41 @@ var threeDigits = {
   ]
 }
 
+var fourDigits = {
+  pass: [
+    '#afe0',
+    '#AF31',
+    '#3cba',
+    '#3CBA',
+    '#b2ff',
+    '#5B2F'
+  ],
+  fail: [
+    'afe0',
+    'AF31',
+    '#3cbg',
+    '#3CBy',
+    '#b2fz'
+  ]
+}
+
+var eightDigits = {
+  pass: [
+    '#afebe300',
+    '#AFEBE3AA',
+    '#3cb371ff',
+    '#3CB371CC',
+    '#556b2f55'
+  ],
+  fail: [
+    'afebe300',
+    'AFEBE3AA',
+    '#3cb371fg',
+    '#3CB371xy',
+    '#556b2fz9'
+  ]
+}
+
 test('hex-color-regex:', function () {
   test('in no strict mode', function () {
     test('six digit hex', function () {
@@ -127,6 +162,44 @@ test('hex-color-regex:', function () {
         })
       })
     })
+    test('eight digit alpha channel hex', function () {
+      test('should be `true`', function () {
+        eightDigits.pass.forEach(function (hex) {
+          test('when `' + hex + '` value', function () {
+            test.equal(hexColorRegex().test(hex), true)
+          })
+        })
+        test('when `foo #ae3f4c bar` value', function () {
+          test.equal(hexColorRegex().test('foo #ae3f4c00 bar'), true)
+        })
+      })
+      test('should be `false`', function () {
+        eightDigits.fail.forEach(function (hex) {
+          test('when `' + hex + '` value', function () {
+            test.equal(hexColorRegex().test(hex), false)
+          })
+        })
+      })
+    })
+    test('four digit alpha channel hex', function () {
+      test('should be `true`', function () {
+        fourDigits.pass.forEach(function (hex) {
+          test('when `' + hex + '` value', function () {
+            test.equal(hexColorRegex().test(hex), true)
+          })
+        })
+        test('when `foo #ae3f4c bar` value', function () {
+          test.equal(hexColorRegex().test('foo #ae3f bar'), true)
+        })
+      })
+      test('should be `false`', function () {
+        fourDigits.fail.forEach(function (hex) {
+          test('when `' + hex + '` value', function () {
+            test.equal(hexColorRegex().test(hex), false)
+          })
+        })
+      })
+    })
     test('using regex().exec(hex)', function () {
       sixDigits.pass.forEach(function (hex) {
         var hexed = hex.replace('}', '')
@@ -158,6 +231,36 @@ test('hex-color-regex:', function () {
 
         test.equal(actual, expected)
       })
+      eightDigits.pass.forEach(function (hex) {
+        var hexed = hex.replace('}', '')
+        test('should match `' + hexed + '` when `' + hex + '` hex', function () {
+          var actual = hexColorRegex().exec(hex)[0]
+          var expected = hexed
+
+          test.equal(actual, expected)
+        })
+      })
+      test('should match `#ae3f4c00` when `foo #ae3f4c00 bar` string', function () {
+        var actual = hexColorRegex().exec('foo #ae3f4c00 bar')[0]
+        var expected = '#ae3f4c00'
+
+        test.equal(actual, expected)
+      })
+      fourDigits.pass.forEach(function (hex) {
+        var hexed = hex.replace('}', '')
+        test('should match `' + hexed + '` when `' + hex + '` hex', function () {
+          var actual = hexColorRegex().exec(hex)[0]
+          var expected = hexed
+
+          test.equal(actual, expected)
+        })
+      })
+      test('should match `#e7f0` when `foo #e7f0 bar` string', function () {
+        var actual = hexColorRegex().exec('foo #e7f0 bar')[0]
+        var expected = '#e7f0'
+
+        test.equal(actual, expected)
+      })
     })
   })
   test('in strict mode', function () {
@@ -173,6 +276,18 @@ test('hex-color-regex:', function () {
     test('string contain three digit hex `foo #e7f bar` return false', function () {
       test.equal(hexColorRegex({strict: true}).test('foo #e7f bar'), false)
     })
+    test('eight digit alpha channel hex `#123fff00}` should return false', function () {
+      test.equal(hexColorRegex({strict: true}).test('#123fff00}'), false)
+    })
+    test('string contain eight digit alpha channel hex `foo #ae3f4cff bar` return false', function () {
+      test.equal(hexColorRegex({strict: true}).test('foo #ae3f4cff bar'), false)
+    })
+    test('four digit alpha channel hex `#f3f0}` should return false', function () {
+      test.equal(hexColorRegex({strict: true}).test('#f3f0}'), false)
+    })
+    test('string contain four digit alpha channel hex `foo #e7ff bar` return false', function () {
+      test.equal(hexColorRegex({strict: true}).test('foo #e7ff bar'), false)
+    })
     test('should not match when `foo #ae3f4c bar` string', function () {
       var actual = hexColorRegex({strict: true}).exec('foo #ae3f4c bar')
       var expected = null
@@ -181,6 +296,18 @@ test('hex-color-regex:', function () {
     })
     test('should not match when `foo #e7f bar` string', function () {
       var actual = hexColorRegex({strict: true}).exec('foo #e7f bar')
+      var expected = null
+
+      test.equal(actual, expected)
+    })
+    test('should not match when `foo #ae3f4cff bar` string', function () {
+      var actual = hexColorRegex({strict: true}).exec('foo #ae3f4cff bar')
+      var expected = null
+
+      test.equal(actual, expected)
+    })
+    test('should not match when `foo #e7ff bar` string', function () {
+      var actual = hexColorRegex({strict: true}).exec('foo #e7ff bar')
       var expected = null
 
       test.equal(actual, expected)


### PR DESCRIPTION
Added tests, and updated regex to match alpha channel hex colors with 4 or 8 values.

The regex checks for 3 or 4 values first, then tries 4+2 or 4+2+2 values.
`/^#([a-f0-9]{3,4}|[a-f0-9]{4}(?:[a-f0-9]{2}){1,2})\b$/i`

But perhaps the longhand would be more readable (perhaps ordered from most common to least):
`/^#([a-f0-9]{6}|[a-f0-9]{3}|[a-f0-9]{8}|[a-f0-9]{4})\b$/i`

fixes #10 